### PR TITLE
make cell_id its own column

### DIFF
--- a/src/retinanalysis/mea_pipeline.py
+++ b/src/retinanalysis/mea_pipeline.py
@@ -40,7 +40,7 @@ class MEAPipeline:
 
     def add_matches_to_protocol(self) -> None:
         inverse_match_dict = {val : key for key, val in self.match_dict.items()}
-        for id in self.response_block.df_spike_times.index:
+        for id in self.response_block.df_spike_times['cell_id']:
             if id in inverse_match_dict:
                 pass
             else:
@@ -63,7 +63,7 @@ class MEAPipeline:
             if id in self.match_dict:
                 type_dict[self.match_dict[id]] = self.analysis_chunk.df_cell_params.query('cell_id == @id')[f'typing_file_{typing_file}'].values[0]
         
-        for id in self.response_block.df_spike_times.index:
+        for id in self.response_block.df_spike_times['cell_id']:
             if id in type_dict:
                 pass
             else:
@@ -259,7 +259,7 @@ class MEAPipeline:
         if protocol_ids is None and cell_types is None:
             cell_types = self.response_block.df_spike_times['cell_type'].unique()
             for ct in cell_types:
-                type_ids = self.response_block.df_spike_times.query('cell_type == @ct').index.values
+                type_ids = self.response_block.df_spike_times.query('cell_type == @ct')['cell_id'].values
                 d_cells_by_type[ct] = [key for key, val in self.match_dict.items() if val in type_ids]
 
                 # remove empty keys
@@ -270,14 +270,14 @@ class MEAPipeline:
         elif protocol_ids is None:
             d_cells_by_type = dict()
             for ct in cell_types:
-                protocol_ids = self.response_block.df_spike_times.query('cell_type == @ct').index.values
+                protocol_ids = self.response_block.df_spike_times.query('cell_type == @ct')['cell_id'].values
                 d_cells_by_type[ct] = [key for key, val in self.match_dict.items() if val in protocol_ids]
 
         # If only ids are given, pull all ids regardless of type
         elif cell_types is None:
             cell_types = self.response_block.df_spike_times['cell_type'].unique()
             for ct in cell_types:
-                type_ids = self.response_block.df_spike_times.query('cell_type == @ct').index.values
+                type_ids = self.response_block.df_spike_times.query('cell_type == @ct')['cell_id'].values
                 d_cells_by_type[ct] = [key for key, val in self.match_dict.items() if (val in protocol_ids
                                                                             and val in type_ids)]
                 # remove empty keys
@@ -287,7 +287,7 @@ class MEAPipeline:
         # If both are given, pull only ids that match both the cell types and the cell ids given
         else:
             for ct in cell_types:
-                protocol_ids = self.response_block.df_spike_times.query('cell_type ==  @ct').index.values
+                protocol_ids = self.response_block.df_spike_times.query('cell_type ==  @ct')['cell_id'].values
                 d_cells_by_type[ct] = [key for key, val in self.match_dict.items() if (val in protocol_ids
                                                                     and val in protocol_ids)]
 

--- a/src/retinanalysis/response.py
+++ b/src/retinanalysis/response.py
@@ -84,7 +84,6 @@ class ResponseBlock:
         self.n_epochs = len(epoch_starts)
         for cell_id in self.cell_ids:
             all_spike_times = []
-            # all_spike_times = np.zeros(self.n_epochs, dtype=object)
             # STs in samples
             cell_sts = self.vcd.get_spike_times_for_cell(cell_id)
             for i in range(self.n_epochs):
@@ -99,12 +98,10 @@ class ResponseBlock:
                 e_sts = e_sts / SAMPLE_RATE * 1000
 
                 all_spike_times.append(e_sts)
-                # all_spike_times[i] = e_sts
 
             d_spike_times['cell_id'].append(cell_id)
             d_spike_times['spike_times'].append(all_spike_times)
         self.df_spike_times = pd.DataFrame(d_spike_times)
-        self.df_spike_times.set_index('cell_id', inplace=True)
 
     def get_max_bins_for_rate(self, bin_rate: float):
         # bin_rate: float, in Hz

--- a/src/retinanalysis/vision_utils.py
+++ b/src/retinanalysis/vision_utils.py
@@ -180,17 +180,17 @@ def get_spike_dict(response_block: ResponseBlock, protocol_ids: List[int] = None
         filtered_df = spike_time_df.query('cell_type == @cell_types')
 
     elif cell_types is None:
-        filtered_df = spike_time_df.query('index == @protocol_ids')
+        filtered_df = spike_time_df.query('cell_id == @protocol_ids')
         cell_types = filtered_df['cell_type'].unique()
         
     else:
-        filtered_df = spike_time_df.query('index == @protocol_ids and cell_type == @cell_types')
+        filtered_df = spike_time_df.query('cell_id == @protocol_ids and cell_type == @cell_types')
 
     d_spike_times = dict()
     for ct in cell_types:
         d_times_and_ids = dict()
         df_type = filtered_df.query('cell_type == @ct')
-        type_ids = df_type.index.values
+        type_ids = df_type['cell_id'].values
         arr_spike_times = [df_type.loc[idx, 'spike_times'] for idx in type_ids]
         arr_spike_times = np.array(arr_spike_times, dtype = object)
         d_times_and_ids['spike_times'] = arr_spike_times


### PR DESCRIPTION
response_block.df_spike_times now has an index column and a cell_id column, and all instances where the index was being used have been fixed to use df_spike_times['cell_id']