### PR TITLE
Added ability to get and plot STAs for cells and cell types

### DIFF
--- a/src/retinanalysis/classes/analysis_chunk.py
+++ b/src/retinanalysis/classes/analysis_chunk.py
@@ -561,7 +561,7 @@ class AnalysisChunk:
             str_self += "  d_spatial_maps not loaded\n"
         return str_self
     
-    def load_stas(self, noise_ids: Optional[int | List[int]] = None, cell_types: Optional[str | List[str]] = None,
+    def get_stas(self, noise_ids: Optional[int | List[int]] = None, cell_types: Optional[str | List[str]] = None,
                   typing_file: Optional[str] = None, padded: bool = True, units: str = 'stixels') -> dict:
         """
         Function for loading the STAs of a given list of cell types and/or noise ids. If both are given, will only
@@ -745,7 +745,7 @@ class AnalysisChunk:
         plt.show() on the figure.
         """
 
-        d_stas = self.load_stas(noise_ids = noise_ids, cell_types = cell_types,
+        d_stas = self.get_stas(noise_ids = noise_ids, cell_types = cell_types,
                                 typing_file = typing_file, padded = padded, units = units)
 
         all_axes = []


### PR DESCRIPTION
Added get_stas and plot_stas methods to analysis chunk. These load the STAs for a given noise chunk given a list of cell ids, a list of cell types, or both. The STAs are organized into a nested dictionary.

If cell typing files are available, the output is organized by of type.
- get_stas provides: `Dict[cell_type: Dict[cell_id, sta]]`
- plot_stas plots one figure per cell type, and one axis per cell. Returns a list of axes arrays

If cell typing files are not available, the output is organized by cell id:

- get_stas returns: `Dict[cell_id, sta]`
- plot_stas plots a single figure with one axis per cells, returns a list with a single axes array inside.

Units can be provided for nearest neighbor scaling, but are set by default to 'stixels'. The output can be padded to remove any crop that was applied to save memory. 