### PR TITLE
Update schema.py

### DIFF
--- a/src/retinanalysis/config/schema.py
+++ b/src/retinanalysis/config/schema.py
@@ -7,7 +7,7 @@ dj.config['database.password'] = 'simple'
 try:
     dj.conn().connect()
     B_CONNECTED = True
-    schema = dj.schema('schema')
+    schema = dj.Schema('schema')
 except Exception as e:
     print(f"Could not connect to DataJoint database: {e}")
     B_CONNECTED = False


### PR DESCRIPTION
Compatibility update. Newer datajoint requires the use of upper case Schema for the object. So dj.schema was changed to dj.Schema. This appears to be backwards compatible with older versions as well.