### PR TITLE
response group bug fix

### DIFF
--- a/src/retinanalysis/classes/response.py
+++ b/src/retinanalysis/classes/response.py
@@ -738,7 +738,7 @@ class MEAResponseGroup:
 
 def create_mea_response_group(
         exp_name: str, ls_datafile_names: List[str], 
-        ss_version: str=None, b_load_fd: bool = False, 
+        ss_version: str='kilosort2.5', b_load_fd: bool = False, 
         b_LED: bool=False, verbose: bool = False
     ):
 


### PR DESCRIPTION
Fixed issue where create_mea_response_group() method reset the ss_version to None by default instead of leaving it as 'kilosort2.5'